### PR TITLE
[FIX] stock_restrict_lot : actually assign and validate move instead …

### DIFF
--- a/stock_restrict_lot/tests/test_restrict_lot.py
+++ b/stock_restrict_lot/tests/test_restrict_lot.py
@@ -373,7 +373,9 @@ class TestRestrictLot(TransactionCase):
     def test_restrict_lot_no_propagation_error(self):
         move, new_lot = self._create_move_with_lot()
         orig_move = move.move_orig_ids
-        orig_move.state = "done"
+        orig_move._action_assign()
+        orig_move.quantity_done = orig_move.product_uom_qty
+        orig_move._action_done()
         self.assertEqual(orig_move.state, "done")
         with self.assertRaises(ValidationError) as m:
             move.restrict_lot_id = new_lot.id


### PR DESCRIPTION
…of changing its state to done in tests

After fixing stock_owner_restriction in OCA/stock-logistics-workflow#1736 
Fixing tests for PR OCA/stock-logistics-workflow#1560 as setting state is not enough to raise ValidationError